### PR TITLE
setup joystick with only the minimum buttons needed

### DIFF
--- a/DanceCtl2-withlights.ino
+++ b/DanceCtl2-withlights.ino
@@ -18,9 +18,13 @@
 
 #include <Joystick.h>
 
-Joystick_ Joystick;
 #define DEBOUNCE_DELAY 5
 #define NBUTTONS 4
+// Set up joystick with 4 buttons, and disable hat switch & all axes
+Joystick_ Joystick( JOYSTICK_DEFAULT_REPORT_ID, JOYSTICK_TYPE_GAMEPAD,
+                    NBUTTONS, 0, false, false, false, false, false,
+                    false, false, false, false, false, false );
+
 static const int buttonPins[NBUTTONS] = {6,7,8,9};
 static const int lightPins[NBUTTONS] = {2,3,4,5};
 static unsigned long lastButtonState[NBUTTONS]; 

--- a/DanceCtl2.ino
+++ b/DanceCtl2.ino
@@ -16,9 +16,13 @@
 
 #include <Joystick.h>
 
-Joystick_ Joystick;
 #define DEBOUNCE_DELAY 5
 #define NBUTTONS 6
+// Set up joystick with 6 buttons, and disable hat switch & all axes
+Joystick_ Joystick( JOYSTICK_DEFAULT_REPORT_ID, JOYSTICK_TYPE_GAMEPAD,
+                    NBUTTONS, 0, false, false, false, false, false,
+                    false, false, false, false, false, false );
+
 static const int buttonPins[NBUTTONS] = {4,5,6,7,8,9};
 static unsigned long lastButtonState[NBUTTONS]; 
 


### PR DESCRIPTION
By default, the controller created by Joystick.h has 32 buttons & multiple analog axes that are never used in a dance pad. Setting up the joystick with the exact buttons we actually use makes the Windows controller properties/test menu cleaner. 
This also fixes a problem that occurs when assigning keybinds; axes are not automatically centered when initialized, so the game may detect a moving analog stick instead of the intended button press.